### PR TITLE
Updated link in LJME_DIGITAL_AUTO_RECOVERY_ERROR_DETECTED description.

### DIFF
--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -6352,7 +6352,7 @@
     {
       "error": 1320,
       "string": "LJME_DIGITAL_AUTO_RECOVERY_ERROR_DETECTED",
-      "description": "During stream, the device buffer overflowed, causing auto-recovery to occur. See labjack.com/digital-auto-recovery-error-detection."
+      "description": "During stream, the device buffer overflowed, causing auto-recovery to occur. See https://labjack.com/digital-auto-recovery-error-detection."
     },
     {
       "error": 1321,


### PR DESCRIPTION
To correct the link on the LabJack website here: https://labjack.com/support/software/api/ljm/error-codes