### PR TITLE
Freqout stream error

### DIFF
--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -105,6 +105,7 @@
       ],
       "readwrite": "RW",
       "tags": ["DIO", "CORE"],
+      "streamable": true,
       "altnames": ["DIO#(0:7)"],
       "displayname": ["FIO Bit #"],
       "description": "Read or set the state of 1 bit of digital I/O.  Also configures the direction to input or output. Read 0=Low AND 1=High. Write 0=Low AND 1=High."
@@ -120,6 +121,7 @@
       ],
       "readwrite": "RW",
       "tags": ["DIO", "CORE"],
+      "streamable": true,
       "altnames": ["DIO#(8:15)"],
       "displayname": ["EIO Bit #"],
       "description": "Read or set the state of 1 bit of digital I/O.  Also configures the direction to input or output. Read 0=Low AND 1=High. Write 0=Low AND 1=High."
@@ -135,6 +137,7 @@
       ],
       "readwrite": "RW",
       "tags": ["DIO", "CORE"],
+      "streamable": true,
       "altnames": ["DIO#(16:19)"],
       "displayname": ["CIO Bit #"],
       "description": "Read or set the state of 1 bit of digital I/O.  Also configures the direction to input or output. Read 0=Low AND 1=High. Write 0=Low AND 1=High."
@@ -149,6 +152,7 @@
       ],
       "readwrite": "RW",
       "tags": ["DIO", "CORE"],
+      "streamable": true,
       "altnames": ["DIO#(20:22)"],
       "displayname": ["MIO Bit #"],
       "description": "Read or set the state of 1 bit of digital I/O.  Also configures the direction to input or output. Read 0=Low AND 1=High. Write 0=Low AND 1=High."

--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -8134,6 +8134,11 @@
       "description": "The STREAM_OUT#_ENABLE register must be set to 1 before writing STREAM_OUT#_LOOP_NUM_VALUES, STREAM_OUT#_SET_LOOP, or any of the STREAM_OUT#_BUFFER_ registers."
     },
     {
+      "error": 2628,
+      "string": "STREAM_RATE_INVALID_TESTOUT",
+      "description": "DAC1_FREQUENCY_OUT_ENABLE should not be enabled for stream rates above 10kHz due to poor performance at higher rates."
+    },
+    {
       "error": 2670,
       "string": "SWDT_ROLLT_INVALID"
     },


### PR DESCRIPTION
Added an error code reflecting that stream enable will throw an error when the sampling rate is above 10kHz and DAC1_FREQUENCY_OUT_ENABLE is enabled.
Possible changes before merging:
- Better error name
- Different threshold frequency for the error to be thrown