### PR TITLE
Update ljm_constants.json. Add last error registers.

### DIFF
--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -5267,7 +5267,7 @@
     },
     {
       "address": 55002,
-      "name": "LAST_ERR_SEQ",
+      "name": "LAST_ERR_FRAME",
       "type": "UINT16",
       "devices": [
         "T8",

--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -5248,7 +5248,7 @@
       ],
       "readwrite": "R",
       "default": 0,
-      "tags": ["CONFIG"],
+      "tags": ["CORE"],
       "description": "Returns the last LabJack error code seen on the device."
     },
     {
@@ -5262,7 +5262,7 @@
       ],
       "readwrite": "R",
       "default": 0,
-      "tags": ["CONFIG"],
+      "tags": ["CORE"],
       "description": "Returns the last Modbus TCP error code seen on the device."
     },
     {
@@ -5276,7 +5276,7 @@
       ],
       "readwrite": "R",
       "default": 0,
-      "tags": ["CONFIG"],
+      "tags": ["CORE"],
       "description": "Returns the frame number that caused the last error."
     },
     {
@@ -5290,7 +5290,7 @@
       ],
       "readwrite": "R",
       "default": 0,
-      "tags": ["CONFIG"],
+      "tags": ["CORE"],
       "description": "Returns the transaction ID of the Modbus TCP packet that caused the last error."
     },
     {

--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -5238,6 +5238,62 @@
       "description": "Write any value to this register to efficiently empty, flush, or otherwise clear data from the FIFO."
     },
     {
+      "address": 55000,
+      "name": "LAST_ERR_DETAIL",
+      "type": "UINT16",
+      "devices": [
+        "T8",
+        "T7",
+        "T4"
+      ],
+      "readwrite": "R",
+      "default": 0,
+      "tags": ["CONFIG"],
+      "description": "Returns the last LabJack error code seen on the device."
+    },
+    {
+      "address": 55001,
+      "name": "LAST_MB_ERR",
+      "type": "UINT16",
+      "devices": [
+        "T8",
+        "T7",
+        "T4"
+      ],
+      "readwrite": "R",
+      "default": 0,
+      "tags": ["CONFIG"],
+      "description": "Returns the last Modbus TCP error code seen on the device."
+    },
+    {
+      "address": 55002,
+      "name": "LAST_ERR_SEQ",
+      "type": "UINT16",
+      "devices": [
+        "T8",
+        "T7",
+        "T4"
+      ],
+      "readwrite": "R",
+      "default": 0,
+      "tags": ["CONFIG"],
+      "description": "Returns the frame number that caused the last error."
+    },
+    {
+      "address": 55003,
+      "name": "LAST_ERR_TRANSACTION_ID",
+      "type": "UINT16",
+      "devices": [
+        "T8",
+        "T7",
+        "T4"
+      ],
+      "readwrite": "R",
+      "default": 0,
+      "tags": ["CONFIG"],
+      "description": "Returns the transaction ID of the Modbus TCP packet that caused the last error."
+    },
+    {
       "address": 55100,
       "name": "TEST",
       "type": "UINT32",


### PR DESCRIPTION
Added registers 55000 - 55003. These contain information about the last error code seen on the device.