### PR TITLE
Update ljm_constants.json

### DIFF
--- a/LabJack/LJM/ljm_constants.json
+++ b/LabJack/LJM/ljm_constants.json
@@ -3279,7 +3279,7 @@
       ],
       "readwrite": "RW",
       "tags": ["DIO_EF", "DIO"],
-      "description": "The clock will count to this value and then start over at zero. The clock pulses counted are those after the divisor. 0 results in the max roll value possible. This is a 32-bit value (0-4294967295) if using a 32-bit clock, and a 16-bit value (0-65535) if using a 16-bit clock."
+      "description": "The clock count will increment continuously and then start over at zero as it reaches the roll value. DIO_EF_CLOCK0 is a 32-bit clock, valid values are 0 to (2^32 - 1). 0 results in the max roll value (2^32)."
     },
     {
       "address": 44910,


### PR DESCRIPTION
Changed the DIO_EF_CLOCK0_ROLL_VALUE description to reflect that it is a 32-bit clock and describe the max roll value.